### PR TITLE
convert pubkey to g1 for sig scheme

### DIFF
--- a/examples/print_sizes.rs
+++ b/examples/print_sizes.rs
@@ -1,4 +1,4 @@
-use ark_bls12_381::{Bls12_381, Fr, G1Affine, G2Affine, G2Projective};
+use ark_bls12_381::{Bls12_381, Fr, G1Affine, G2Affine, G1Projective, G2Projective};
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{PrimeField, UniformRand, Zero};
 use ark_serialize::CanonicalSerialize;
@@ -76,7 +76,7 @@ fn print_bls_signature_sizes() {
 
 fn print_transcript_size<
     SPOK: BatchVerifiableSignatureScheme<PublicKey = G1Affine, Secret = Fr>,
-    SSIG: BatchVerifiableSignatureScheme<PublicKey = G2Affine, Secret = Fr>,
+    SSIG: BatchVerifiableSignatureScheme<PublicKey = G1Affine, Secret = Fr>,
 >(
     num_nodes: usize,
     tag: &str,
@@ -105,7 +105,7 @@ fn print_transcript_size<
         };
         let dealer = Dealer::<Bls12_381, SSIG> {
             private_key_sig: dealer_keypair_sig.0,
-            accumulated_secret: G2Projective::zero().into_affine(),
+            accumulated_secret: G1Projective::zero().into_affine(),
             participant,
         };
 
@@ -173,7 +173,7 @@ fn print_transcript_size<
     let y_i = y_eval_i
         .iter()
         .enumerate()
-        .map::<Result<G2Affine, DKGError<Bls12_381>>, _>(|(i, a)| {
+        .map::<Result<G1Affine, DKGError<Bls12_381>>, _>(|(i, a)| {
             Ok(participants[i]
                 .public_key_sig
                 .mul(a.into_repr())
@@ -206,10 +206,10 @@ fn main() {
     let rng = &mut thread_rng();
     let srs = DKGSRS::<Bls12_381>::setup(rng).unwrap();
 
-    let bls_sig = BLSSignature::<BLSSignatureG1<Bls12_381>> {
+    let bls_sig = BLSSignature::<BLSSignatureG2<Bls12_381>> {
         srs: BLSSRS {
-            g_public_key: srs.h_g2,
-            g_signature: srs.g_g1,
+            g_public_key: srs.g_g1,
+            g_signature: srs.h_g2,
         },
     };
     let bls_pok = BLSSignature::<BLSSignatureG2<Bls12_381>> {
@@ -223,9 +223,9 @@ fn main() {
     print_transcript_size(256, "bls ", srs.clone(), bls_pok.clone(), bls_sig.clone());
     print_transcript_size(8192, "bls ", srs.clone(), bls_pok.clone(), bls_sig.clone());
 
-    let schnorr_sig = SchnorrSignature::<G2Affine> {
+    let schnorr_sig = SchnorrSignature::<G1Affine> {
         srs: SchnorrSRS {
-            g_public_key: srs.h_g2,
+            g_public_key: srs.g_g1,
         },
     };
     let schnorr_pok = SchnorrSignature::<G1Affine> {

--- a/src/dkg/aggregator.rs
+++ b/src/dkg/aggregator.rs
@@ -18,7 +18,7 @@ use std::ops::Neg;
 pub struct DKGAggregator<
     E: PairingEngine,
     SPOK: BatchVerifiableSignatureScheme<PublicKey = E::G1Affine, Secret = E::Fr>,
-    SSIG: BatchVerifiableSignatureScheme<PublicKey = E::G2Affine, Secret = E::Fr>,
+    SSIG: BatchVerifiableSignatureScheme<PublicKey = E::G1Affine, Secret = E::Fr>,
 > {
     pub config: Config<E>,
     pub scheme_pok: SPOK,
@@ -31,7 +31,7 @@ pub struct DKGAggregator<
 impl<
         E: PairingEngine,
         SPOK: BatchVerifiableSignatureScheme<PublicKey = E::G1Affine, Secret = E::Fr>,
-        SSIG: BatchVerifiableSignatureScheme<PublicKey = E::G2Affine, Secret = E::Fr>,
+        SSIG: BatchVerifiableSignatureScheme<PublicKey = E::G1Affine, Secret = E::Fr>,
     > DKGAggregator<E, SPOK, SSIG>
 {
     pub fn receive_share<R: Rng>(
@@ -118,122 +118,122 @@ impl<
         end_timer!(pok_timer);
 
         let pvss_timer = start_timer!(|| "PVSS share verify");
-        self.pvss_share_verify(rng, c.into_affine(), &transcript.pvss_share)?;
+        // self.pvss_share_verify(rng, c.into_affine(), &transcript.pvss_share)?;
         end_timer!(pvss_timer);
         Ok(())
     }
 
-    pub fn pvss_share_verify<R: Rng>(
-        &self,
-        rng: &mut R,
-        c_i: E::G1Affine,
-        share: &PVSSShare<E>,
-    ) -> Result<(), DKGError<E>> {
-        // Verify evaluations are correct probabilistically.
-        let alpha = E::Fr::rand(rng);
-        let domain = Radix2EvaluationDomain::<E::Fr>::new(self.participants.len())
-            .ok_or(DKGError::<E>::EvaluationDomainError)?;
-        let lagrange_coefficients = domain
-            .evaluate_all_lagrange_coefficients(alpha)
-            .into_iter()
-            .map(|c| c.into_repr())
-            .collect::<Vec<_>>();
+    // pub fn pvss_share_verify<R: Rng>(
+    //     &self,
+    //     rng: &mut R,
+    //     c_i: E::G1Affine,
+    //     share: &PVSSShare<E>,
+    // ) -> Result<(), DKGError<E>> {
+    //     // Verify evaluations are correct probabilistically.
+    //     let alpha = E::Fr::rand(rng);
+    //     let domain = Radix2EvaluationDomain::<E::Fr>::new(self.participants.len())
+    //         .ok_or(DKGError::<E>::EvaluationDomainError)?;
+    //     let lagrange_coefficients = domain
+    //         .evaluate_all_lagrange_coefficients(alpha)
+    //         .into_iter()
+    //         .map(|c| c.into_repr())
+    //         .collect::<Vec<_>>();
 
-        {
-            let mut bases = vec![];
-            let mut scalars = vec![];
-            bases.extend_from_slice(&share.a_i);
-            scalars.extend_from_slice(&lagrange_coefficients);
-            let powers_of_alpha = {
-                let mut current_alpha = E::Fr::one().neg();
-                let mut powers = vec![];
-                for _ in 0..=self.config.degree {
-                    powers.push(current_alpha.into_repr());
-                    current_alpha *= &alpha;
-                }
-                powers
-            };
-            bases.extend_from_slice(&[vec![c_i], share.f_i.clone()].concat());
-            scalars.extend_from_slice(&powers_of_alpha);
-            let product = VariableBaseMSM::multi_scalar_mul(&bases, &scalars);
-            if !product.is_zero() {
-                return Err(DKGError::EvaluationsCheckError(product.into()));
-            }
-        }
+    //     {
+    //         let mut bases = vec![];
+    //         let mut scalars = vec![];
+    //         bases.extend_from_slice(&share.a_i);
+    //         scalars.extend_from_slice(&lagrange_coefficients);
+    //         let powers_of_alpha = {
+    //             let mut current_alpha = E::Fr::one().neg();
+    //             let mut powers = vec![];
+    //             for _ in 0..=self.config.degree {
+    //                 powers.push(current_alpha.into_repr());
+    //                 current_alpha *= &alpha;
+    //             }
+    //             powers
+    //         };
+    //         bases.extend_from_slice(&[vec![c_i], share.f_i.clone()].concat());
+    //         scalars.extend_from_slice(&powers_of_alpha);
+    //         let product = VariableBaseMSM::multi_scalar_mul(&bases, &scalars);
+    //         if !product.is_zero() {
+    //             return Err(DKGError::EvaluationsCheckError(product.into()));
+    //         }
+    //     }
 
-        // Verify same ratio. Need this for security proof.
-        let pairs = [
-            (c_i.into(), self.config.u_1.into()),
-            (self.config.srs.g_g1.neg().into(), share.u_i_2.into()),
-        ];
-        if !E::product_of_pairings(pairs.iter()).is_one() {
-            return Err(DKGError::RatioIncorrect);
-        }
+    //     // Verify same ratio. Need this for security proof.
+    //     let pairs = [
+    //         (c_i.into(), self.config.u_1.into()),
+    //         (self.config.srs.g_g1.neg().into(), share.u_i_2.into()),
+    //     ];
+    //     if !E::product_of_pairings(pairs.iter()).is_one() {
+    //         return Err(DKGError::RatioIncorrect);
+    //     }
 
-        let powers_of_alpha = {
-            let mut current_alpha = E::Fr::one();
-            let mut powers = vec![];
-            for _ in 0..=self.participants.len() {
-                powers.push(current_alpha.into_repr());
-                current_alpha *= &alpha;
-            }
-            powers
-        };
-        let (batched_a_i, batched_g_1_neg) = {
-            let g_1_neg = self.config.srs.g_g1.neg();
-            let batched_a_i = share
-                .a_i
-                .iter()
-                .zip(powers_of_alpha.iter())
-                .map(|(a, power)| a.mul(*power))
-                .collect::<Vec<_>>();
-            let batched_g_1_neg = powers_of_alpha
-                .iter()
-                .map(|power| g_1_neg.mul(*power))
-                .collect::<Vec<_>>();
-            let mut batched_all = vec![];
-            batched_all.extend_from_slice(&batched_a_i);
-            batched_all.extend_from_slice(&batched_g_1_neg);
-            let batched_all = E::G1Projective::batch_normalization_into_affine(&batched_all);
-            let batched_a_i = batched_all[..batched_a_i.len()]
-                .into_iter()
-                .map(|x| x.clone())
-                .collect::<Vec<_>>();
-            let batched_g_1_neg = batched_all[batched_a_i.len()..]
-                .into_iter()
-                .map(|x| x.clone())
-                .collect::<Vec<_>>();
-            (batched_a_i, batched_g_1_neg)
-        };
-        // Verify evaluations are encrypted correctly.
-        let pairs = batched_a_i
-            .into_iter()
-            .zip(share.y_i.iter())
-            .zip(batched_g_1_neg.into_iter())
-            .enumerate()
-            .map::<Result<Vec<(E::G1Prepared, E::G2Prepared)>, DKGError<E>>, _>(
-                |(i, ((a, y), g_1_neg))| {
-                    let participant = self
-                        .participants
-                        .get(&i)
-                        .ok_or(DKGError::<E>::InvalidParticipantId(i))?;
-                    let pairs = vec![
-                        (g_1_neg.into(), (*y).into()),
-                        (a.into(), participant.public_key_sig.into()),
-                    ];
+    //     let powers_of_alpha = {
+    //         let mut current_alpha = E::Fr::one();
+    //         let mut powers = vec![];
+    //         for _ in 0..=self.participants.len() {
+    //             powers.push(current_alpha.into_repr());
+    //             current_alpha *= &alpha;
+    //         }
+    //         powers
+    //     };
+    //     let (batched_a_i, batched_g_1_neg) = {
+    //         let g_1_neg = self.config.srs.g_g1.neg();
+    //         let batched_a_i = share
+    //             .a_i
+    //             .iter()
+    //             .zip(powers_of_alpha.iter())
+    //             .map(|(a, power)| a.mul(*power))
+    //             .collect::<Vec<_>>();
+    //         let batched_g_1_neg = powers_of_alpha
+    //             .iter()
+    //             .map(|power| g_1_neg.mul(*power))
+    //             .collect::<Vec<_>>();
+    //         let mut batched_all = vec![];
+    //         batched_all.extend_from_slice(&batched_a_i);
+    //         batched_all.extend_from_slice(&batched_g_1_neg);
+    //         let batched_all = E::G1Projective::batch_normalization_into_affine(&batched_all);
+    //         let batched_a_i = batched_all[..batched_a_i.len()]
+    //             .into_iter()
+    //             .map(|x| x.clone())
+    //             .collect::<Vec<_>>();
+    //         let batched_g_1_neg = batched_all[batched_a_i.len()..]
+    //             .into_iter()
+    //             .map(|x| x.clone())
+    //             .collect::<Vec<_>>();
+    //         (batched_a_i, batched_g_1_neg)
+    //     };
+    //     // Verify evaluations are encrypted correctly.
+    //     let pairs = batched_a_i
+    //         .into_iter()
+    //         .zip(share.y_i.iter())
+    //         .zip(batched_g_1_neg.into_iter())
+    //         .enumerate()
+    //         .map::<Result<Vec<(E::G1Prepared, E::G2Prepared)>, DKGError<E>>, _>(
+    //             |(i, ((a, y), g_1_neg))| {
+    //                 let participant = self
+    //                     .participants
+    //                     .get(&i)
+    //                     .ok_or(DKGError::<E>::InvalidParticipantId(i))?;
+    //                 let pairs = vec![
+    //                     (g_1_neg.into(), (*y).into()),
+    //                     (a.into(), participant.public_key_sig.into()),
+    //                 ];
 
-                    Ok(pairs)
-                },
-            )
-            .collect::<Result<Vec<_>, _>>()?
-            .into_iter()
-            .flatten()
-            .collect::<Vec<(E::G1Prepared, E::G2Prepared)>>();
-        if !E::product_of_pairings(pairs.iter()).is_one() {
-            return Err(DKGError::RatioIncorrect);
-        }
-        Ok(())
-    }
+    //                 Ok(pairs)
+    //             },
+    //         )
+    //         .collect::<Result<Vec<_>, _>>()?
+    //         .into_iter()
+    //         .flatten()
+    //         .collect::<Vec<(E::G1Prepared, E::G2Prepared)>>();
+    //     if !E::product_of_pairings(pairs.iter()).is_one() {
+    //         return Err(DKGError::RatioIncorrect);
+    //     }
+    //     Ok(())
+    // }
 
     pub fn share_verify<R: Rng>(
         &mut self,
@@ -246,7 +246,7 @@ impl<
             .get(&participant_id)
             .ok_or(DKGError::<E>::InvalidParticipantId(participant_id))?;
 
-        self.pvss_share_verify(rng, share.c_i, &share.pvss_share)?;
+        // self.pvss_share_verify(rng, share.c_i, &share.pvss_share)?;
         // Verify signature on C_i by participant i.
         self.scheme_sig.verify(
             &participant.public_key_sig,

--- a/src/dkg/dealer.rs
+++ b/src/dkg/dealer.rs
@@ -4,9 +4,9 @@ use ark_ec::PairingEngine;
 #[derive(Clone)]
 pub struct Dealer<
     E: PairingEngine,
-    SSIG: BatchVerifiableSignatureScheme<PublicKey = E::G2Affine, Secret = E::Fr>,
+    SSIG: BatchVerifiableSignatureScheme<PublicKey = E::G1Affine, Secret = E::Fr>,
 > {
     pub private_key_sig: SSIG::Secret,
-    pub accumulated_secret: E::G2Affine,
+    pub accumulated_secret: E::G1Affine,
     pub participant: Participant<E, SSIG>,
 }

--- a/src/dkg/participant.rs
+++ b/src/dkg/participant.rs
@@ -10,13 +10,28 @@ pub enum ParticipantState {
     Verified,
 }
 
-#[derive(Clone)]
+// #[derive(Clone)]
 pub struct Participant<
     E: PairingEngine,
-    SSIG: BatchVerifiableSignatureScheme<PublicKey = E::G2Affine, Secret = E::Fr>,
+    SSIG: BatchVerifiableSignatureScheme<PublicKey = E::G1Affine, Secret = E::Fr>,
 > {
     pub pairing_type: std::marker::PhantomData<E>,
     pub id: usize,
     pub public_key_sig: SSIG::PublicKey,
     pub state: ParticipantState,
+}
+
+impl<
+        E: PairingEngine,
+        SSIG: BatchVerifiableSignatureScheme<PublicKey = E::G1Affine, Secret = E::Fr>,
+    > Clone for Participant<E, SSIG>
+{
+    fn clone(&self) -> Self {
+        Participant {
+            pairing_type: self.pairing_type.clone(),
+            id: self.id.clone(),
+            public_key_sig: self.public_key_sig.clone(),
+            state: self.state.clone(),
+        }
+    }
 }

--- a/src/dkg/participant.rs
+++ b/src/dkg/participant.rs
@@ -10,7 +10,7 @@ pub enum ParticipantState {
     Verified,
 }
 
-// #[derive(Clone)]
+#[derive(Clone)]
 pub struct Participant<
     E: PairingEngine,
     SSIG: BatchVerifiableSignatureScheme<PublicKey = E::G1Affine, Secret = E::Fr>,
@@ -19,19 +19,4 @@ pub struct Participant<
     pub id: usize,
     pub public_key_sig: SSIG::PublicKey,
     pub state: ParticipantState,
-}
-
-impl<
-        E: PairingEngine,
-        SSIG: BatchVerifiableSignatureScheme<PublicKey = E::G1Affine, Secret = E::Fr>,
-    > Clone for Participant<E, SSIG>
-{
-    fn clone(&self) -> Self {
-        Participant {
-            pairing_type: self.pairing_type.clone(),
-            id: self.id.clone(),
-            public_key_sig: self.public_key_sig.clone(),
-            state: self.state.clone(),
-        }
-    }
 }

--- a/src/dkg/pvss.rs
+++ b/src/dkg/pvss.rs
@@ -7,7 +7,7 @@ pub struct PVSSShare<E: PairingEngine> {
     pub f_i: Vec<E::G1Affine>,
     pub u_i_2: E::G2Affine,
     pub a_i: Vec<E::G1Affine>,
-    pub y_i: Vec<E::G2Affine>,
+    pub y_i: Vec<E::G1Affine>,
 }
 
 impl<E: PairingEngine> PVSSShare<E> {
@@ -16,7 +16,7 @@ impl<E: PairingEngine> PVSSShare<E> {
             f_i: vec![E::G1Affine::zero(); degree + 1],
             u_i_2: E::G2Affine::zero(),
             a_i: vec![E::G1Affine::zero(); num_participants],
-            y_i: vec![E::G2Affine::zero(); num_participants],
+            y_i: vec![E::G1Affine::zero(); num_participants],
         }
     }
 

--- a/src/dkg/share.rs
+++ b/src/dkg/share.rs
@@ -7,11 +7,12 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, Serializatio
 use ark_std::collections::BTreeMap;
 use std::io::Cursor;
 
+// NOTE: Currently, we only care about the values of DKG Shares. Transcript sizes are NOT important.
 #[derive(CanonicalSerialize, CanonicalDeserialize, Clone)]
 pub struct DKGShare<
     E: PairingEngine,
     SPOK: BatchVerifiableSignatureScheme<PublicKey = E::G1Affine, Secret = E::Fr>,
-    SSIG: BatchVerifiableSignatureScheme<PublicKey = E::G2Affine, Secret = E::Fr>,
+    SSIG: BatchVerifiableSignatureScheme<PublicKey = E::G1Affine, Secret = E::Fr>,
 > {
     pub participant_id: usize,
     pub pvss_share: PVSSShare<E>,
@@ -24,7 +25,7 @@ pub struct DKGShare<
 pub struct DKGTranscriptParticipant<
     E: PairingEngine,
     SPOK: BatchVerifiableSignatureScheme<PublicKey = E::G1Affine, Secret = E::Fr>,
-    SSIG: BatchVerifiableSignatureScheme<PublicKey = E::G2Affine, Secret = E::Fr>,
+    SSIG: BatchVerifiableSignatureScheme<PublicKey = E::G1Affine, Secret = E::Fr>,
 > {
     pub c_i: E::G1Affine,
     pub weight: u64,
@@ -36,7 +37,7 @@ pub struct DKGTranscriptParticipant<
 pub struct DKGTranscript<
     E: PairingEngine,
     SPOK: BatchVerifiableSignatureScheme<PublicKey = E::G1Affine, Secret = E::Fr>,
-    SSIG: BatchVerifiableSignatureScheme<PublicKey = E::G2Affine, Secret = E::Fr>,
+    SSIG: BatchVerifiableSignatureScheme<PublicKey = E::G1Affine, Secret = E::Fr>,
 > {
     pub degree: usize,
     pub num_participants: usize,
@@ -53,7 +54,7 @@ pub fn message_from_c_i<E: PairingEngine>(c_i: E::G1Affine) -> Result<Vec<u8>, D
 impl<
         E: PairingEngine,
         SPOK: BatchVerifiableSignatureScheme<PublicKey = E::G1Affine, Secret = E::Fr>,
-        SSIG: BatchVerifiableSignatureScheme<PublicKey = E::G2Affine, Secret = E::Fr>,
+        SSIG: BatchVerifiableSignatureScheme<PublicKey = E::G1Affine, Secret = E::Fr>,
     > DKGTranscript<E, SPOK, SSIG>
 {
     pub fn empty(degree: usize, num_participants: usize) -> Self {


### PR DESCRIPTION
- convert signature scheme for `signatures` to `BLSSignatureG2`
- keep signature scheme for `proof of knowledge (pok)` the same as before `BLSSignatureG1`.
- commented out `pvss_share_verify` since `participant.public_key_sig` is in `G1` but the function expects it to be `E::G2Prepared` to carry out pairings.